### PR TITLE
Fix dataset paths for portability

### DIFF
--- a/AssociationRules.ipynb
+++ b/AssociationRules.ipynb
@@ -87,7 +87,7 @@
    ],
    "source": [
     "bakery_data = spark.read.csv(\n",
-    "    \"/Users/ssyan110/Codes/Big_data_in_machine_learning/Final/Data/75000/75000-out1.csv\",\n",
+    "    \"./75000-out1.csv\",\n",
     "    header=False,\n",
     "    inferSchema=True\n",
     ")\n",
@@ -502,10 +502,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transactions = spark.read.csv(\"/Users/ssyan110/Codes/Big_data_in_machine_learning/Final/Data/75000/75000i.csv\", header=False, inferSchema=True)\n",
+    "transactions = spark.read.csv(\"./75000i.csv\", header=False, inferSchema=True)\n",
     "transactions = transactions.toDF(\"TransactionID\", \"Quantity\", \"ItemID\")\n",
     "\n",
-    "goods = spark.read.csv(\"/Users/ssyan110/Codes/Big_data_in_machine_learning/Final/Data/75000/goods.csv\", header=True, inferSchema=True)"
+    "goods = spark.read.csv(\"./goods.csv\", header=True, inferSchema=True)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix dataset loading in AssociationRules.ipynb to use relative paths

## Testing
- `python -m nbconvert --to script AssociationRules.ipynb --stdout | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68443b5459648322b5e26c6ff7228e6d